### PR TITLE
Added `build.yaml` for CD

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,36 @@
+name: Deploy DotNet project to Azure Function App
+
+on:
+  [workflow_dispatch]
+
+env:
+  AZURE_FUNCTIONAPP_NAME: 'resumeapireactor'
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: '.'       # set this to the path to your function app project, defaults to the repository root
+  DOTNET_VERSION: '6.0.x'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+    - name: 'Checkout GitHub Action'
+      uses: actions/checkout@v3
+
+    - name: Setup DotNet ${{ env.DOTNET_VERSION }} Environment
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: 'Resolve Project Dependencies Using Dotnet'
+      shell: bash
+      run: |
+        pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
+        dotnet build --configuration Release --output ./output
+        popd
+    - name: 'Run Azure Functions Action'
+      uses: Azure/functions-action@v1
+      id: fa
+      with:
+        app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+        package: '${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}/output'
+        publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}


### PR DESCRIPTION
The GitHub Actions deploys the function to the `resumeapireactor` Functions App

<img width="1332" alt="Screenshot 2022-11-04 at 9 11 57 PM" src="https://user-images.githubusercontent.com/45825464/200094564-d64609d4-f960-41dc-8f1e-9197d295ea7e.png">

<img width="1068" alt="Screenshot 2022-11-04 at 9 12 26 PM" src="https://user-images.githubusercontent.com/45825464/200094565-07020787-02ef-485f-a71a-6b95444a0465.png">


Need to add the publish profile for the Function App as a secret to the repository `AZURE_FUNCTIONAPP_PUBLISH_PROFILE`